### PR TITLE
[hotfix/pdf-upload-logic] PDF 업로드 시 업로드 로직을 페이지 단에서 처리

### DIFF
--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -5,9 +5,6 @@ const nextConfig: NextConfig = {
   images: {
     remotePatterns: [new URL('https://shvxzuvqnlffnldbvtdf.supabase.co/**')],
   },
-  experimental: {
-    middlewareClientMaxBodySize: '50mb',
-  },
 }
 
 export default nextConfig


### PR DESCRIPTION
- 불필요한 next.config 옵션 제거
- PDF 업로드 시 업로드 로직을 api route가 아닌 페이지 단에서 처리